### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/ask-a-question.md
+++ b/.github/ISSUE_TEMPLATE/ask-a-question.md
@@ -1,0 +1,16 @@
+---
+name: Ask a Question
+about: I'm not reporting a bug or contributing code, I just want to ask a question!
+title: "[Question]"
+labels: question
+assignees: ''
+
+---
+
+Ask your question Here! 
+
+You may also request help from the [ALFS-Discuss Mailing List](mailto:alfs-discuss@lists.linuxfromscratch.org)
+
+Do Not Edit below this line
+***
+@automate-lfs/automate-lfs-questions

--- a/.github/ISSUE_TEMPLATE/ask-a-question.md
+++ b/.github/ISSUE_TEMPLATE/ask-a-question.md
@@ -1,7 +1,7 @@
 ---
 name: Ask a Question
 about: I'm not reporting a bug or contributing code, I just want to ask a question!
-title: "[Question]"
+title: "[Question] Replace with a short title for your question"
 labels: question
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots/Terminal output**
+If applicable, add screenshots to help explain your problem.
+
+**Environment Details (please complete the following information):**
+ - Host OS: [e.g. output from uname -a]
+ - Target architecture [e.g. x86, amd64, x86-64]
+ - jhalfs version [e.g. 2.4 or commit hash]
+ - Book version [e.g. stable/development and systemd/sysv]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: ''
+title: '[Bug] Replace with a short title for your bug'
 labels: bug
 assignees: ''
 
@@ -17,11 +17,14 @@ Steps to reproduce the behavior:
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
+**Expected Behavior**
 A clear and concise description of what you expected to happen.
 
-**Screenshots/Terminal output**
-If applicable, add screenshots to help explain your problem.
+**Observed Behavior**
+What actually happened.
+
+**Screenshots/Terminal Output**
+If applicable, add screenshots or terminal output to help explain your problem.
 
 **Environment Details (please complete the following information):**
  - Host OS: [e.g. output from uname -a]

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: '[Bug] Replace with a short title for your bug'
+title: "[Bug] Replace with a short title for your bug"
 labels: bug
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: ''
+title: "[Feature] Replace with a short descriptiton of your feature"
 labels: enhancement
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/pull_request_template.md
+++ b/.github/ISSUE_TEMPLATE/pull_request_template.md
@@ -1,0 +1,8 @@
+Fixes # .
+
+Changes proposed in this pull request:
+-
+-
+-
+
+@automate-lfs/automate-lfs-repo-admins

--- a/.github/ISSUE_TEMPLATE/pull_request_template.md
+++ b/.github/ISSUE_TEMPLATE/pull_request_template.md
@@ -5,4 +5,6 @@ Changes proposed in this pull request:
 -
 -
 
+Do not edit below this line
+***
 @automate-lfs/automate-lfs-repo-admins


### PR DESCRIPTION
Closes #5 

Adds the following issue templates:
- [x] Bug report
- [x] Feature Request
- [x] Question
- [x] Pull request

Additional items to complete:
- [x] Accept philschatz/project-bot installation (enables new issues to be auto-assigned to projects)