### PR TITLE
Fix gen install 1

### DIFF
--- a/BLFS/xsl/gen-install.xsl
+++ b/BLFS/xsl/gen-install.xsl
@@ -34,9 +34,14 @@
     </xsl:variable>
 
     <xsl:variable
+         name="prec-screen"
+         select="preceding::screen[not(@role='nodump') and ./userinput][1]
+                        [ancestor::sect2 = current()/ancestor::sect2]"/>
+
+    <xsl:variable
          name="prec-string"
-         select="string(preceding-sibling::screen[not(@role='nodump') and
-                                                      ./userinput][1])"/>
+         select="string($prec-screen)"/>
+
 <!--
     <xsl:message>
       <xsl:text>
@@ -59,16 +64,14 @@ List of preceding siblings for "</xsl:text>
       <xsl:choose>
         <xsl:when
              test="$prec-string='' or
-                   (preceding-sibling::screen[not(@role='nodump') and
-                                                      ./userinput] |
-                    preceding-sibling::para/command[contains(text(),'check') or
-                                                    contains(text(),'test')]
+                   (preceding::screen[not(@role='nodump') and
+                                                 ./userinput] |
+                    preceding::command[contains(text(),'check') or
+                                       contains(text(),'test')]
                    )[last()][self::command]">
           <xsl:text>none</xsl:text>
         </xsl:when>
-        <xsl:when
-           test="preceding-sibling::screen
-                    [not(@role='nodump') and ./userinput][1][not(@role)]">
+        <xsl:when test="$prec-screen[not(@role)]">
           <xsl:text>non-root</xsl:text>
         </xsl:when>
         <xsl:when test="contains($prec-string,'useradd') or
@@ -89,24 +92,26 @@ List of preceding siblings for "</xsl:text>
     </xsl:variable>
 
     <xsl:variable
+         name="follow-screen"
+         select="following::screen[not(@role='nodump') and ./userinput][1]
+                        [ancestor::sect2 = current()/ancestor::sect2]"/>
+
+    <xsl:variable
          name="follow-string"
-         select="string(following-sibling::screen[not(@role='nodump') and
-                                                      ./userinput][1])"/>
+         select="string($follow-screen)"/>
 
     <xsl:variable name="follow-nature">
       <xsl:choose>
         <xsl:when
              test="$follow-string='' or
-                   (following-sibling::screen[not(@role='nodump') and
-                                                      ./userinput] |
-                    following-sibling::para/command[contains(text(),'check') or
-                                                    contains(text(),'test')]
+                   (following::screen[not(@role='nodump') and
+                                                 ./userinput] |
+                    following::command[contains(text(),'check') or
+                                       contains(text(),'test')]
                    )[1][self::command]">
           <xsl:text>none</xsl:text>
         </xsl:when>
-        <xsl:when
-           test="following-sibling::screen
-                    [not(@role='nodump') and ./userinput][1][not(@role)]">
+        <xsl:when test="$follow-screen[not(@role)]">
           <xsl:text>non-root</xsl:text>
         </xsl:when>
         <xsl:when test="contains($follow-string,'useradd') or

--- a/BLFS/xsl/scripts.xsl
+++ b/BLFS/xsl/scripts.xsl
@@ -1024,8 +1024,18 @@ echo Size after install: $(sudo du -skx --exclude home /) >> $INFOLOG
                select="substring-after($instructions,'&#xA;')"/>
         </xsl:call-template>
       </xsl:when>
+      <xsl:when
+           test="substring($instructions,string-length($instructions))=' '">
+        <xsl:call-template name="remove-end-space">
+          <xsl:with-param
+               name="instructions"
+               select="substring($instructions,
+                                 1,
+                                 string-length($instructions)-1)"/>
+        </xsl:call-template>
+      </xsl:when>
       <xsl:otherwise>
-        <xsl:copy-of select="normalize-space($instructions)"/>
+        <xsl:copy-of select="$instructions"/>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>


### PR DESCRIPTION
**Changes proposed in this pull request**:
- **BLFS/xsl/gen-install.xsl**: use `preceding`/`following` instead of `preceding-sibling`/`following-sibling`. But limit to nodes having a common sect2 ancestor. This allows finding the preceding or
following screen tags, only when they are in the install role. Fixes #13 
- **BLFS/xsl/scripts.xsl**: fix a just discovered bug: when a double ampersand is removed, only remove trailing spaces, and not leading ones.

@automate-lfs/automate-lfs-repo-admins
