### PR TITLE
Fix rebuilding some LFS packages in BLFS:

### DIFF
--- a/BLFS/xsl/gen_pkg_list.xsl
+++ b/BLFS/xsl/gen_pkg_list.xsl
@@ -43,7 +43,7 @@
           <xsl:attribute name="id">lfs-8</xsl:attribute>
           <xsl:text>&#xA;      </xsl:text>
           <name>LFS Chapter 8</name>
-          <xsl:apply-templates select='document($lfs-full)//chapter[@id="chapter-bootable"]/sect1/sect1info[./productname="linux"]'/>
+          <xsl:apply-templates select='document($lfs-full)//chapter[@id="chapter-bootable"]/sect1/sect1info[./productname="kernel"]'/>
           <xsl:text>&#xA;    </xsl:text>
         </sublist>
         <sublist>
@@ -85,8 +85,7 @@
     <xsl:text>      </xsl:text>
     <xsl:choose>
 <!-- Never update linux headers -->
-      <xsl:when test="./productname='linux'
-                      and ancestor::chapter[@id='chapter-building-system']"/>
+      <xsl:when test="./productname='linux-headers'"/>
 <!-- Gcc version is taken from BLFS -->
       <xsl:when test="./productname='gcc'"/>
 <!-- Shadow version is taken from BLFS -->
@@ -97,8 +96,7 @@
       <xsl:when test="./productname='dbus'"/>
 <!-- Systemd version is taken from BLFS -->
       <xsl:when test="./productname='systemd'"/>
-<!-- Same for python and ninja -->
-      <xsl:when test="./productname='ninja'"/>
+<!-- Same for python3 -->
       <xsl:when test="./productname='Python'"/>
       <xsl:otherwise>
         <package><xsl:text>&#xA;        </xsl:text>

--- a/BLFS/xsl/lfs_make_book.xsl
+++ b/BLFS/xsl/lfs_make_book.xsl
@@ -14,9 +14,9 @@
                       $package='dbus' or
                       $package='vim' or
                       $package='systemd' or
-                      $package='ninja' or
                       $package='Python' or
                       $package='shadow'"/>
+      <xsl:when test="$package='kernel'">true</xsl:when>
       <xsl:when test="$package='LFS-Release'">true</xsl:when>
       <xsl:otherwise>
         <xsl:for-each select="document($lfsbook)">
@@ -34,10 +34,9 @@
                       $package='dbus' or
                       $package='vim' or
                       $package='systemd' or
-                      $package='ninja' or
                       $package='Python' or
                       $package='shadow'"/>
-      <xsl:when test="$package='linux'">
+      <xsl:when test="$package='kernel'">
         <xsl:for-each select="document($lfsbook)">
           <xsl:apply-templates select="key('idlfs',$package)[ancestor::chapter/@id='chapter-bootable']" mode="lfs"/>
         </xsl:for-each>


### PR DESCRIPTION
- kernel is now "kernel" in setc1info
- headers are now linux-headers in setc1info (do not rebuild them)
- ninja is not in BLFS anymore.

Apart from ninja, those changes are made necessary by the changes in sect1info information in lfs book. Those changes have been taken into account when building the lfs book, but not when rebuilding lfs packages when using blfs tools.